### PR TITLE
Change license to BSD

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -24,6 +24,6 @@ test:
 
 about:
   home: https://github.com/conjure-cp/conjure-notebook
-  license: Mozilla Public License 2.0 (MPL 2.0)
-  license_file: LICENSE.txt
-  summary: Conjure extension for jupyter notebook
+  license: The 3-Clause BSD License
+  license_file: LICENSE
+  summary: Conjure extension for Jupyter Notebooks


### PR DESCRIPTION
Hi @ogabek96 - would you be happy to change the license to BSD-3?

See https://opensource.org/licenses/BSD-3-Clause

This would mean it has the same license as Conjure, it might make life easier for users.